### PR TITLE
Fixes issue #8: file not found unless absolute path is given

### DIFF
--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -38,7 +38,7 @@ class JSONSchemaDirective(Directive):
                                        self.arguments[0])
                 env.note_dependency(relpath)
 
-                schema = JSONSchema.loadfromfile(relpath)
+                schema = JSONSchema.loadfromfile(os.path.join(env.srcdir, relpath))
             else:
                 schema = JSONSchema.loadfromfile(''.join(self.content))
         except ValueError as exc:


### PR DESCRIPTION
A fix for #8 

The call to `JSONSchema.loadfromfile()` did not include the path to the
file, but only the filename itself. This fails if Sphinx is configured
to use separate source and build directories. (note that the check with
`os.access()` uses the absolute path by concatenating the absolute path
with the filename. THis is why the test for the existence of the file
*does not* fail, but the attempt to open the file *does fail*.

This patch uses the same syntax as in the check with `os.access()`, by
concatenating the absolute path to the JSON filename.