### PR TITLE
Resolve local JSON References

### DIFF
--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -21,6 +21,35 @@ else:
     from collections import OrderedDict
 
 
+def is_ref(obj):
+    return (isinstance(obj, (dict, OrderedDict)) and len(obj) == 1 and isinstance(obj.get("$ref", None), string_types))
+
+
+def resolve_ref(obj, root):
+    if is_ref(obj):
+        ref = obj["$ref"]
+        parts = ref.split("/")
+        if parts and parts[0] == "#":  # only resolve ref in same document
+            current = root
+            for p in parts[1:]:
+                if isinstance(current, (list, tuple)):
+                    current = current[int(p)]
+                else:
+                    current = current[p]
+            return current
+    return obj
+
+
+def resolve_all_refs(obj, root):
+    obj = resolve_ref(obj, root)
+    if isinstance(obj, (dict, OrderedDict)):
+        return OrderedDict((k, resolve_all_refs(v, root)) for k, v in obj.items())
+    elif isinstance(obj, (list, tuple)):
+        return [resolve_all_refs(e, root) for e in obj]
+    else:
+        return obj
+
+
 class JSONSchemaDirective(Directive):
     has_content = True
     required_arguments = 1
@@ -120,11 +149,13 @@ class JSONSchema(object):
     @classmethod
     def load(cls, reader):
         obj = json.load(reader, object_pairs_hook=OrderedDict)
+        obj = resolve_all_refs(obj, obj)
         return cls.instantiate(None, obj)
 
     @classmethod
     def loads(cls, string):
         obj = json.loads(string, object_pairs_hook=OrderedDict)
+        obj = resolve_all_refs(obj, obj)
         return cls.instantiate(None, obj)
 
     @classmethod

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import sys
+from collections import OrderedDict
+import json
+from sphinxcontrib.jsonschema import resolve_all_refs, resolve_ref
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestJSONReference(unittest.TestCase):
+    def test_resolve_ref(self):
+        thing = OrderedDict({"title": "stuff"})
+        ref = {"$ref": "#/definitions/somename/0"}
+        data = {"definitions": {"somename": [thing]}}
+        resolved = resolve_ref(ref, data)
+        self.assertEqual(resolved, thing)
+
+    def test_resolve_all_refs(self):
+        data1 = json.loads("""{
+            "definitions": {
+                "thing": {
+                    "title": "stuff"
+                }
+            },
+            "properties": {
+                "a": {"$ref": "#/definitions/thing"}
+            }
+        }""", object_pairs_hook=OrderedDict)
+        data2 = json.loads("""{
+            "definitions": {
+                "thing": {
+                    "title": "stuff"
+                }
+
+            },
+            "properties": {
+                "a": {
+                    "title": "stuff"
+                }
+            }
+        }""", object_pairs_hook=OrderedDict)
+        resolved = resolve_all_refs(data1, data1)
+        self.assertEqual(resolved, data2)


### PR DESCRIPTION
With this change local JSON References can be resolved.  They are widely used like in the example at http://json-schema.org/example2.html

