### PR TITLE
Use jsonref

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 long_desc = open('README.rst').read()
 
-requires = ['Sphinx>=0.6']
+requires = ['Sphinx>=0.6', 'jsonref']
 
 setup(
     name='sphinxcontrib-jsonschema',

--- a/sphinxcontrib/jsonschema.py
+++ b/sphinxcontrib/jsonschema.py
@@ -8,6 +8,7 @@
 import io
 import os
 import sys
+import jsonref
 from six import string_types
 from docutils import nodes
 from docutils.statemachine import ViewList
@@ -119,12 +120,12 @@ def simplify(obj):
 class JSONSchema(object):
     @classmethod
     def load(cls, reader):
-        obj = json.load(reader, object_pairs_hook=OrderedDict)
+        obj = jsonref.load(reader, object_pairs_hook=OrderedDict)
         return cls.instantiate(None, obj)
 
     @classmethod
     def loads(cls, string):
-        obj = json.loads(string, object_pairs_hook=OrderedDict)
+        obj = jsonref.loads(string, object_pairs_hook=OrderedDict)
         return cls.instantiate(None, obj)
 
     @classmethod

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+import sys
+from collections import OrderedDict
+import json
+from sphinxcontrib.jsonschema import resolve_all_refs, resolve_ref
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestJSONReference(unittest.TestCase):
+    def test_resolve_ref(self):
+        thing = OrderedDict({"title": "stuff"})
+        ref = {"$ref": "#/definitions/somename/0"}
+        data = {"definitions": {"somename": [thing]}}
+        resolved = resolve_ref(ref, data)
+        self.assertEqual(resolved, thing)
+
+    def test_resolve_all_refs(self):
+        data1 = json.loads("""{
+            "definitions": {
+                "thing": {
+                    "title": "stuff"
+                }
+            },
+            "properties": {
+                "a": {"$ref": "#/definitions/thing"}
+            }
+        }""", object_pairs_hook=OrderedDict)
+        data2 = json.loads("""{
+            "definitions": {
+                "thing": {
+                    "title": "stuff"
+                }
+
+            },
+            "properties": {
+                "a": {
+                    "title": "stuff"
+                }
+            }
+        }""", object_pairs_hook=OrderedDict)
+        resolved = resolve_all_refs(data1, data1)
+        self.assertEqual(resolved, data2)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -3,7 +3,7 @@
 import sys
 from collections import OrderedDict
 import json
-from sphinxcontrib.jsonschema import resolve_all_refs, resolve_ref
+from sphinxcontrib.jsonschema import JSONSchema
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -12,15 +12,8 @@ else:
 
 
 class TestJSONReference(unittest.TestCase):
-    def test_resolve_ref(self):
-        thing = OrderedDict({"title": "stuff"})
-        ref = {"$ref": "#/definitions/somename/0"}
-        data = {"definitions": {"somename": [thing]}}
-        resolved = resolve_ref(ref, data)
-        self.assertEqual(resolved, thing)
-
-    def test_resolve_all_refs(self):
-        data1 = json.loads("""{
+    def test_jsonschema_loads(self):
+        resolved = JSONSchema.loads("""{
             "definitions": {
                 "thing": {
                     "title": "stuff"
@@ -29,8 +22,8 @@ class TestJSONReference(unittest.TestCase):
             "properties": {
                 "a": {"$ref": "#/definitions/thing"}
             }
-        }""", object_pairs_hook=OrderedDict)
-        data2 = json.loads("""{
+        }""").attributes
+        expected = json.loads("""{
             "definitions": {
                 "thing": {
                     "title": "stuff"
@@ -43,5 +36,4 @@ class TestJSONReference(unittest.TestCase):
                 }
             }
         }""", object_pairs_hook=OrderedDict)
-        resolved = resolve_all_refs(data1, data1)
-        self.assertEqual(resolved, data2)
+        self.assertEqual(resolved, expected)

--- a/tests/test_references.py
+++ b/tests/test_references.py
@@ -4,6 +4,7 @@ import sys
 from collections import OrderedDict
 import json
 from sphinxcontrib.jsonschema import JSONSchema
+import tempfile
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -23,6 +24,35 @@ class TestJSONReference(unittest.TestCase):
                 "a": {"$ref": "#/definitions/thing"}
             }
         }""").attributes
+        expected = json.loads("""{
+            "definitions": {
+                "thing": {
+                    "title": "stuff"
+                }
+
+            },
+            "properties": {
+                "a": {
+                    "title": "stuff"
+                }
+            }
+        }""", object_pairs_hook=OrderedDict)
+        self.assertEqual(resolved, expected)
+
+    def test_jsonschema_load(self):
+        with tempfile.TemporaryFile(mode='w+') as fp:
+            fp.write("""{
+                "definitions": {
+                    "thing": {
+                        "title": "stuff"
+                    }
+                },
+                "properties": {
+                    "a": {"$ref": "#/definitions/thing"}
+                }
+            }""")
+            fp.seek(0)
+            resolved = JSONSchema.load(fp).attributes
         expected = json.loads("""{
             "definitions": {
                 "thing": {

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps=
     flake8
     pytest
     sphinx-testing
+    .
 passenv=
     TRAVIS*
 commands=


### PR DESCRIPTION
An alternative approach to https://github.com/tk0miya/sphinxcontrib-jsonschema/pull/11 (sorry, I'd missed that pull request when I started on this).
Advantages: relies on a more fully featured and tested library.
Disadvantages: an extra pip dependency.

I've been looking into this as part of making the extension fit our needs for the Open Contracting Data Standard docs https://github.com/open-contracting/standard. Other changes at: 
https://github.com/tk0miya/sphinxcontrib-jsonschema/compare/master...OpenDataServices:master. I'll make some more pull requests for other changes, if you're interested.